### PR TITLE
Install bower files from gulp

### DIFF
--- a/portal/README.md
+++ b/portal/README.md
@@ -8,7 +8,6 @@ This is the SIEBAC portal, built with node.js and express.
 
 ```shell
 npm install
-(cd src/site && ../../node_modules/.bin/bower install)
 npm run build
 node dist/app.js
 ```

--- a/portal/gulpfile.js
+++ b/portal/gulpfile.js
@@ -1,16 +1,5 @@
 var gulp = require('gulp');
 
-var lib = require('bower-files')({
-  json: './src/site/bower.json',
-  dir: './src/site/bower_components',
-  overrides: {
-    react: {
-      main: ['react.js', 'JSXTransformer.js'],
-      dependencies: {}
-    }
-  }
-});
-
 //var sass = require('gulp-sass');
 
 //gulp.task('sass', function () {
@@ -20,6 +9,17 @@ var lib = require('bower-files')({
 //});
 
 gulp.task('bowerLibs', function() {
+  var lib = require('bower-files')({
+    json: './src/site/bower.json',
+    dir: './src/site/bower_components',
+    overrides: {
+      react: {
+        main: ['react.js', 'JSXTransformer.js'],
+        dependencies: {}
+      }
+    }
+  });
+
   return gulp.src(lib.ext('js').files)
     .pipe(gulp.dest('./build/site/lib/'))
 });

--- a/portal/gulpfile.js
+++ b/portal/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp');
+var gulpBower = require('gulp-bower');
 
 //var sass = require('gulp-sass');
 
@@ -8,7 +9,11 @@ var gulp = require('gulp');
 //    .pipe(gulp.dest('./build/site/style'));
 //});
 
-gulp.task('bowerLibs', function() {
+gulp.task('bowerInstall', function() {
+  return gulpBower({ cwd: './src/site/', directory: './bower_components', cmd: 'install' });
+});
+
+gulp.task('bowerLibs', ['bowerInstall'], function() {
   var lib = require('bower-files')({
     json: './src/site/bower.json',
     dir: './src/site/bower_components',

--- a/portal/gulpfile.js
+++ b/portal/gulpfile.js
@@ -44,7 +44,4 @@ gulp.task('distStyles', function() {
     .pipe(gulp.dest('./dist/public/style'));
 });
 
-gulp.task('build', ['distLibs', 'distSources', 'distStyles'], function() {
-
-});
-
+gulp.task('build', ['bowerLibs', 'distLibs', 'distSources', 'distStyles']);

--- a/portal/gulpfile.js
+++ b/portal/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task('bowerLibs', ['bowerInstall'], function() {
     .pipe(gulp.dest('./build/site/lib/'))
 });
 
-gulp.task('distLibs', function() {
+gulp.task('distLibs', ['bowerLibs'], function() {
   return gulp.src('./build/site/lib/*.js')
     .pipe(gulp.dest('./dist/public/lib'));
 });
@@ -44,4 +44,4 @@ gulp.task('distStyles', function() {
     .pipe(gulp.dest('./dist/public/style'));
 });
 
-gulp.task('build', ['bowerLibs', 'distLibs', 'distSources', 'distStyles']);
+gulp.task('build', ['distLibs', 'distSources', 'distStyles']);

--- a/portal/package.json
+++ b/portal/package.json
@@ -27,6 +27,7 @@
     "bower-files": "latest",
     "browserify": "latest",
     "gulp": "latest",
+    "gulp-bower": "0.0.10",
     "mocha": "latest",
     "supertest": "latest"
   }


### PR DESCRIPTION
Quando estamos criando um projeto com um build pipeline, é muito importante incluir todos os processos que cada passo dependende no processo de execução.

Nos estamos utilizando o Bower para facilitar a instalacao de bibiliotecas para o front-end. O processo de execucao dele estava fora do Gulp, nossa ferramenta escolhida para gerenciar todo o build.

Caso não executássemos `bower install` na pasta certa antes de rodar o `npm run build`, teriamos um erro.
O erro por causa da ordem de execução de processos é menos que o ideal para se ter em um build pipeline. Apesar de termos as instruções no README, o erro ainda iria causar um pouco de confusão, principalmente para ambientes que acabaram de clonar o repositorio e nunca haviam rodado a instalação inicial.

```
$ ./node_modules/.bin/gulp bowerInstall
evalmachine.<anonymous>:502
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory '/Users/bruno/repos/siebac/portal/src/site/bower_components/lodash/.bower.json'
    at Error (native)
    at Object.fs.openSync (evalmachine.<anonymous>:502:18)
    at Object.fs.readFileSync (evalmachine.<anonymous>:354:15)
    at readJsonSync (/Users/bruno/repos/siebac/portal/node_modules/bower-files/node_modules/read-json-sync/index.js:10:31)
    at new Component (/Users/bruno/repos/siebac/portal/node_modules/bower-files/lib/component.js:27:15)
    at /Users/bruno/repos/siebac/portal/node_modules/bower-files/lib/utils/get-deps.js:9:12
    at Array.map (native)
    at getDependencies (/Users/bruno/repos/siebac/portal/node_modules/bower-files/lib/utils/get-deps.js:8:38)
    at new MainComponent (/Users/bruno/repos/siebac/portal/node_modules/bower-files/lib/main-component.js:32:23)
```

Exemplos dessa situação são novos membros na equipe e novas maquinas adicionadas na ferramenta de integração continua. O erro seria tambem mais complicado para pessoas que já estão no projeto de reproduzir, dado que eles já possuem a pasta necessaria, o que não causaria o erro.

Alem de resolver o erro, adicionar esses processos como dependencias das tarefas no processo de build garantem que elas sejam executadas por todos, evitando que arquivos fiquem desatualizados e que o processo seja seguido igualmente tanto por desenvolvedores quanto durante o processo de entrega.
