### PR TITLE
Reorganize build

### DIFF
--- a/portal/gulpfile.js
+++ b/portal/gulpfile.js
@@ -7,7 +7,7 @@ var browserify = require('browserify');
 var transform = require('vinyl-transform');
 
 gulp.task('bundle', ['distLibs', 'distSources'], function () {
-  var browserified = transform(function(filename) {
+  var browserified = transform(function (filename) {
     return browserify({entries: filename, debug: true}).bundle();
   });
 
@@ -22,11 +22,11 @@ gulp.task('sass', function () {
     .pipe(gulp.dest('./build/site/style'));
 });
 
-gulp.task('bowerInstall', function() {
+gulp.task('bowerInstall', function () {
   return gulpBower({ cwd: './src/site/', directory: './bower_components', cmd: 'install' });
 });
 
-gulp.task('bowerLibs', ['bowerInstall'], function() {
+gulp.task('bowerLibs', ['bowerInstall'], function () {
   var lib = require('bower-files')({
     json: './src/site/bower.json',
     dir: './src/site/bower_components',
@@ -44,47 +44,47 @@ gulp.task('bowerLibs', ['bowerInstall'], function() {
     .pipe(gulp.dest('./build/site/lib/'));
 });
 
-gulp.task('buildStatic', function() {
+gulp.task('buildStatic', function () {
   return gulp.src(['./src/site/static/*.*'])
     .pipe(gulp.dest('./build/site/static'));
 });
 
-gulp.task('buildReact', function() {
+gulp.task('buildReact', function () {
   return gulp.src(['./src/site/*.jsx'])
     .pipe(react())
     .pipe(gulp.dest('./build/site'));
 });
 
-gulp.task('buildJavascript', function() {
+gulp.task('buildJavascript', function () {
   return gulp.src(['./src/site/*.js'])
     .pipe(gulp.dest('./build/site'));
 });
 
-gulp.task('lint', function() {
+gulp.task('lint', function () {
   return gulp.src(['./src/site/static/*.js'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failOnError());
 });
 
-gulp.task('distLibs', ['bowerLibs', 'lint'], function() {
+gulp.task('distLibs', ['bowerLibs', 'lint'], function () {
   return gulp.src('./build/site/lib/*.js')
     .pipe(gulp.dest('./dist/public/lib'));
 });
 
-gulp.task('distSources', ['lint', 'buildStatic', 'buildJavascript', 'buildReact'], function() {
+gulp.task('distSources', ['lint', 'buildStatic', 'buildJavascript', 'buildReact'], function () {
   return gulp.src(['./build/site/*.js', './build/site/static/**/*.*'])
     .pipe(gulp.dest('./dist/public'));
 });
 
-gulp.task('distStyles', ['sass', 'bowerLibs'], function() {
+gulp.task('distStyles', ['sass', 'bowerLibs'], function () {
   return gulp.src(['./build/site/style/*.css'])
     .pipe(gulp.dest('./dist/public/style'));
 });
 
 gulp.task('build', ['bundle', 'distStyles']);
 
-gulp.task('watch', function() {
+gulp.task('watch', function () {
   gulp.watch(['./src/site/**/*.html','./src/site/**/*.js', './src/site/**/*.jsx'], ['distSources']);
   gulp.watch('./src/site/style/*.scss', ['distStyles']);
 });

--- a/portal/gulpfile.js
+++ b/portal/gulpfile.js
@@ -3,6 +3,18 @@ var gulpBower = require('gulp-bower');
 var sass = require('gulp-sass');
 var eslint = require('gulp-eslint');
 var react = require('gulp-react');
+var browserify = require('browserify');
+var transform = require('vinyl-transform');
+
+gulp.task('bundle', ['distLibs', 'distSources'], function () {
+  var browserified = transform(function(filename) {
+    return browserify({entries: filename, debug: true}).bundle();
+  });
+
+  return gulp.src('./build/site/main.js')
+    .pipe(browserified)
+    .pipe(gulp.dest('./dist/public'));
+});
 
 gulp.task('sass', function () {
   return gulp.src('./src/site/style/*.scss')
@@ -70,10 +82,9 @@ gulp.task('distStyles', ['sass', 'bowerLibs'], function() {
     .pipe(gulp.dest('./dist/public/style'));
 });
 
-gulp.task('build', ['distLibs', 'distSources', 'distStyles']);
+gulp.task('build', ['bundle', 'distStyles']);
 
 gulp.task('watch', function() {
   gulp.watch(['./src/site/**/*.html','./src/site/**/*.js', './src/site/**/*.jsx'], ['distSources']);
   gulp.watch('./src/site/style/*.scss', ['distStyles']);
-
 });

--- a/portal/package.json
+++ b/portal/package.json
@@ -33,6 +33,7 @@
     "gulp-react": "^3.0.1",
     "gulp-sass": "^1.3.3",
     "mocha": "latest",
-    "supertest": "latest"
+    "supertest": "latest",
+    "vinyl-transform": "^1.0.0"
   }
 }

--- a/portal/src/site/domain.js
+++ b/portal/src/site/domain.js
@@ -1,1 +1,3 @@
-console.log('hey, im domain  22');
+module.exports = function () {
+  return 'hey, im domain  22';
+};

--- a/portal/src/site/main.js
+++ b/portal/src/site/main.js
@@ -1,0 +1,2 @@
+var view = require('./view.js');
+view.render();

--- a/portal/src/site/static/index.html
+++ b/portal/src/site/static/index.html
@@ -12,7 +12,6 @@
     </header>
     <main id="main"></main>
     <footer></footer>
-    <script type="text/javascript" src="domain.js"></script> 
-    <script type="text/javascript" src="view.js"></script> 
+    <script type="text/javascript" src="main.js"></script> 
   </body>
 </html>

--- a/portal/src/site/view.jsx
+++ b/portal/src/site/view.jsx
@@ -2,7 +2,7 @@ var CarSide = React.createClass({
   render: function() {
     return <section class="car-chooser">
       <h3>Escolha o seu carro</h3>
-    </section>  
+    </section>
   }
 });
 
@@ -10,14 +10,18 @@ var AlternativeSide = React.createClass({
   render: function() {
     return <section class="alternative-chooser">
       <h3>Agora, se você não tivesse um carro, o que você usaria no lugar?</h3>
-    </section>  
+    </section>
   }
 });
 
-React.render(
-  <div>   
-    <CarSide/>
-    <AlternativeSide/>
-  </div>,
-  document.getElementById('main')
-);
+module.exports = {
+  render: function () {
+    React.render(
+      <div>
+        <CarSide/>
+        <AlternativeSide/>
+      </div>,
+      document.getElementById('main')
+    );
+  }
+};

--- a/portal/src/site/view.jsx
+++ b/portal/src/site/view.jsx
@@ -1,16 +1,20 @@
 var CarSide = React.createClass({
   render: function() {
-    return <section class="car-chooser">
-      <h3>Escolha o seu carro</h3>
-    </section>
+    return (
+      <section class="car-chooser">
+        <h3>Escolha o seu carro</h3>
+      </section>
+    );
   }
 });
 
 var AlternativeSide = React.createClass({
   render: function() {
-    return <section class="alternative-chooser">
-      <h3>Agora, se você não tivesse um carro, o que você usaria no lugar?</h3>
-    </section>
+    return (
+      <section class="alternative-chooser">
+        <h3>Agora, se você não tivesse um carro, o que você usaria no lugar?</h3>
+      </section>
+    );
   }
 });
 


### PR DESCRIPTION
A idea da reorganização é deixar mais proximo de uma linha de produção, com a instalação de bibliotecas acontencendo no começo, junto com a compilação do jsx -> js, passado pela verificação do lint (e em breve testes), bundling e dist.

Para poder visualizar melhor, este grafico mostra as dependencias dos passos antes de aplicar a mudança.
![before](https://cloud.githubusercontent.com/assets/109474/6771584/cef142d0-d0c0-11e4-8cac-83c8b86f7a3d.png)

Agora, com a mudança das dependencias:
![reorganized](https://cloud.githubusercontent.com/assets/109474/6771585/d0aff2ce-d0c0-11e4-9ee8-0c435c39dc67.png)
